### PR TITLE
Rails v8からArel::Nodes::Function#aliasメソッドが削除されたため修正

### DIFF
--- a/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
+++ b/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
@@ -39,7 +39,6 @@ module MultiTenant
 
     def function(obj)
       visit obj.expressions
-      visit obj.alias
       visit obj.distinct
     end
     alias visit_Arel_Nodes_Avg    function
@@ -54,12 +53,10 @@ module MultiTenant
       visit obj.name
       visit obj.expressions
       visit obj.distinct
-      visit obj.alias
     end
 
     def visit_Arel_Nodes_Count(obj)
       visit obj.expressions
-      visit obj.alias
       visit obj.distinct
     end
 

--- a/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
+++ b/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
@@ -7,6 +7,8 @@ module MultiTenant
       super()
     end
 
+    DISPATCH = dispatch_cache
+
     private
 
     def visit(obj, _ = nil)
@@ -17,6 +19,7 @@ module MultiTenant
     def unary(obj)
       visit obj.expr
     end
+    # rubocop:disable Naming/MethodName
     alias visit_Arel_Nodes_Else              unary
     alias visit_Arel_Nodes_Group             unary
     alias visit_Arel_Nodes_Cube              unary
@@ -46,8 +49,6 @@ module MultiTenant
     alias visit_Arel_Nodes_Max    function
     alias visit_Arel_Nodes_Min    function
     alias visit_Arel_Nodes_Sum    function
-
-    # rubocop:disable Naming/MethodName
 
     def visit_Arel_Nodes_NamedFunction(obj)
       visit obj.name
@@ -193,8 +194,6 @@ module MultiTenant
         visit(v)
       end
     end
-
-    DISPATCH = dispatch_cache
 
     # rubocop:disable Naming/AccessorMethodName
     def get_dispatch_cache


### PR DESCRIPTION
TASK-5740

uuuo-webをRails v8へアップデートする作業を行なったが、v8からArel::Nodes::Function#aliasメソッドが削除されている。
activerecord-multi-tenantではそのメソッドを参照してたため、Nomethodエラーが発生した。
そのため該当部分を修正した。

fork元にもPRがあるが、マージされていない。一旦forkしたこのリポジトリを修正する。

https://github.com/citusdata/activerecord-multi-tenant/pull/284